### PR TITLE
Retry when async url generator throws.

### DIFF
--- a/src/waterfall/Waterfall.spec.ts
+++ b/src/waterfall/Waterfall.spec.ts
@@ -260,6 +260,24 @@ describe("Waterfall", () => {
             }, 100);
 
         });
+
+        it("should retry when generator throws", (done) => {
+            let called = false;
+            const validUrl = `ws://localtest.me:4752/${rnd}`;
+            const urlGenerator = async (attempt: number, ws: Waterfall) => {
+                if (called) {
+                    return validUrl;
+                } else {
+                    called = true;
+                    throw new Error("First attempt fails.");
+                }
+            };
+            ws = new Waterfall(urlGenerator);
+            setTimeout(() => {
+                expect(ws.readyState).to.equal(WebSocket.OPEN);
+                done();
+            }, 100);
+        });
     });
 
     describe("when disconnect with emitClose option", () => {

--- a/src/waterfall/Waterfall.ts
+++ b/src/waterfall/Waterfall.ts
@@ -252,7 +252,7 @@ export class Waterfall extends Shell {
 
         this.attempts++;
         const urlOrPromise: any = this._urlGenerator(this.attempts, this);
-        urlOrPromise.then ? urlOrPromise.then(doOpen) : doOpen(urlOrPromise);
+        urlOrPromise.then ? urlOrPromise.then(doOpen).catch(() => this.failed()) : doOpen(urlOrPromise);
     }
 
 }


### PR DESCRIPTION
As discussed in #210, this PR treats throws from async url generator as failures to connect and makes waterfall retry in those situations according to retryPolicy. 

